### PR TITLE
Add Terraform state and initial setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Background / Context
+Please say at least one sentence.
+
+## Aim / Implementation
+Please say at least one sentence.
+
+## Examples / Tests
+Please say at least one sentence.

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,15 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+*.terraform.lock*
 
 # Crash log files
 crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Mission OPS example project
+A sample project to deploy apps in AWS
+
+## Initial AWS environment setup
+
+This repo has several prerequisites:
+- you should have a valid AWS environment with a pre-setup awscli and proper authentication
+
+
+First, we need to create an S3 bucket for the soul purpose of storing the terraform state.
+*Note*: we are not going to use a consensus mechanics in the form of a DynamoDB database in this example.
+```
+aws s3api create-bucket --bucket <prefix>-state --region <region> --create-bucket-configuration LocationConstraint=<region>
+```
+
+Example:
+```
+aws s3api create-bucket --bucket mission-ops-state --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1
+```
+
+*Improtant*:
+Since the terraform state stores very important resources and they are very small in size,
+it is strongly recommended to enable S3 bucket versioning:
+
+```
+aws s3api put-bucket-versioning --bucket <bucket> --versioning-configuration Status=Enabled
+```
+
+Example:
+```
+aws s3api put-bucket-versioning --bucket mission-ops-state --versioning-configuration Status=Enabled
+```
+
+### Initiating Terraform environment
+
+Before running everything, take note of the variables in `terraform/backend.tfvars`.
+Those are needed for the initial setup and should reflect your environment and the bucket you created in the previous step.
+
+
+To initiate the terraform state simply run:
+```
+cd terraform
+terraform init -backend-config=backend.tfvars
+```
+
+Expected result:
+```
+Terraform has been successfully initialized!
+```
+
+## Style Guide:
+- App names are kebap-cased
+- variables are snake_cased

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.48.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = var.bucket
+    key    = "terraform.tfstate"
+    region = var.region
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket to store Terraform state."
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "The name of the region in which the terraform S3 state bucket resides."
+  type        = string
+  default     = "eu-central-1"
+}


### PR DESCRIPTION
## Background / Context

This Repo will store terraform code, so we need to set up the environment for that.

## Aim / Implementation

This would mean:
- having a proper .gitignore
- setting up the terraform state in an s3 bucket
- actually initiating the state with no resources

Since this is a one-contributor example project - no need for a DynamoDB to setup the locking.

## Examples / Tests
```
~/Repo/mission-ops/terraform (add-terraform-state $) terraform init -backend-config=backend.tfvars                                                                                                                                                                                                <aws:mine>
Alias tip: tfi -backend-config=backend.tfvars

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 5.48.0"...
- Installing hashicorp/aws v5.48.0...
- Installed hashicorp/aws v5.48.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
