### PR TITLE
Add AWS Lambda db-connection-check function

### DIFF
--- a/python/lambda/lambda_function.py
+++ b/python/lambda/lambda_function.py
@@ -1,0 +1,41 @@
+import os
+import socket
+
+def main(event, context):
+    hostname = os.environ.get('DB_HOST')
+    port = int(os.environ.get('DB_PORT'))
+
+    is_open = is_port_open(hostname, port)
+
+    if is_open:
+        result = f"Port {port} on {hostname} is open."
+        print(result)
+        return {
+            'statusCode': 200,
+            'body': result
+        }
+    else:
+        result = f"Port {port} on {hostname} is closed."
+        print(result)
+        return {
+            'statusCode': 200,
+            'body': result
+        }
+
+def is_port_open(hostname, port):
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        sock.settimeout(1)
+
+        result = sock.connect_ex((hostname, port))
+
+        if result == 0:
+            return True
+        else:
+            return False
+    except Exception as e:
+        print("Error:", e)
+        return False
+    finally:
+        sock.close()

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -1,3 +1,14 @@
+resource "aws_db_parameter_group" "log_access" {
+  name        = "${var.name}-db-param-group"
+  family      = "${var.database.engine}${regex("^[0-9]+", var.database.version)}"
+  description = "DB parameter group with read-only access"
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+}
+
 resource "aws_db_instance" "rds" {
   identifier             = "${var.name}-db"
   allocated_storage      = var.database.storage
@@ -10,6 +21,7 @@ resource "aws_db_instance" "rds" {
   username               = var.db_admin_user
   password               = var.db_admin_pass
   publicly_accessible    = var.database.is_public
+  parameter_group_name   = aws_db_parameter_group.log_access.name
   skip_final_snapshot    = true
   db_subnet_group_name   = aws_db_subnet_group.rds.name
   vpc_security_group_ids = [aws_security_group.rds_security_group.id]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,36 @@
+data "archive_file" "lambda_function_zip" {
+  type        = "zip"
+  output_path = "/tmp/lambda_function.zip"
+  source_file = "${path.module}/../python/lambda/lambda_function.py"
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name    = "db-connection-check"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_function.main"
+  runtime          = "python3.12"
+  filename         = "/tmp/lambda_function.zip"
+  source_code_hash = data.archive_file.lambda_function_zip.output_base64sha256
+
+  vpc_config {
+    subnet_ids         = local.lambda_subnet_ids
+    security_group_ids = [aws_security_group.lambda_security_group.id]
+  }
+
+  environment {
+    variables     = {
+      DB_HOST     = aws_db_instance.rds.address
+      DB_PORT     = aws_db_instance.rds.port
+      DB_NAME     = aws_db_instance.rds.db_name
+      DB_USER     = var.db_admin_user
+      DB_PASSWORD = var.db_admin_pass
+    }
+  }
+}
+
+resource "aws_lambda_permission" "lambda_permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -19,6 +19,18 @@ locals {
     if subnet.tags.type == "db"
   ]
 
+  lambda_subnet_ids = [
+    for key, subnet in aws_subnet.subnets :
+    subnet.id
+    if subnet.tags.type == "apps-private"
+  ]
+
+  db_subnets_cidrs = [
+    for key, subnet in aws_subnet.subnets :
+    subnet.cidr_block
+    if subnet.tags.type == "db"
+  ]
+
   all_subnets_cidrs = [
     for key, subnet in aws_subnet.subnets :
     subnet.cidr_block

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -13,7 +13,7 @@ locals {
     }
   )
 
-  db_subnets_id = [
+  db_subnet_ids = [
     for key, subnet in aws_subnet.subnets :
     subnet.id
     if subnet.tags.type == "db"

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -14,3 +14,74 @@ resource "aws_security_group" "rds_security_group" {
     Name = "rds-security-group"
   }
 }
+
+resource "aws_security_group" "lambda_security_group" {
+  name        = "lambda-security-group"
+  vpc_id      = aws_vpc.vpc.id
+  description = "Security group for the Lambda instances"
+
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = local.db_subnets_cidrs
+  }
+
+  tags = {
+    Name = "lambda-security-group"
+  }
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "lambda.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name        = "lambda-policy"
+  description = "Policy for the Lambda function"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        "Resource": "arn:aws:logs:*:*:*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "rds-db:connect"
+        ],
+        "Resource": "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -81,10 +81,12 @@ variable "db_admin_user" {
   type        = string
   description = "The database user with admin access."
   default     = ""
+  sensitive   = true
 }
 
 variable "db_admin_pass" {
   type        = string
   description = "The database admin user password."
   default     = ""
+  sensitive   = true
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -26,7 +26,7 @@ resource "aws_subnet" "subnets" {
 
 resource "aws_db_subnet_group" "rds" {
   name       = "${var.name}-db"
-  subnet_ids = local.db_subnets_id
+  subnet_ids = local.db_subnet_ids
 
   tags = {
     Name = "My DB subnet group"


### PR DESCRIPTION
## Background / Context

Now that we have a database, it is time to create an automation for a Lambda function that will connect to this database and perform computation. We will use the `apps-private` subnet and make sure we have a very strict firewall.

## Aim / Implementation

The function is the first one in AWS Lambda so we are creating a lot of
supporting infra:
- security groups to and from the Lambda subnets
- special permissions, that will be attached to the lambda functions
- a lambda function in a specific VPC subnet that is isolated from the
  DB and the rest
- a sample python db-connect script that will check for TCP connectivity
  to the database

PS: this role is very important when we create a lambda in a custom VPC:
https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html

## Examples / Tests

Actually deployed and tested - the DB connection is OK:
![Screenshot 2024-05-08 at 14 03 18](https://github.com/mihailgmihaylov/mission-ops/assets/19683080/ede68e6f-f07a-4bd2-9361-c0530c91ce63)

