### PR TITLE
Add a sample "hello-app-runner" App Runner instance

### DIFF
--- a/terraform/application.tf
+++ b/terraform/application.tf
@@ -1,0 +1,53 @@
+resource "aws_apprunner_observability_configuration" "backend" {
+  observability_configuration_name = "${var.name}-backend"
+
+  trace_configuration {
+    vendor = "AWSXRAY"
+  }
+}
+
+resource "aws_apprunner_vpc_connector" "backend_connector" {
+  vpc_connector_name = "${var.name}-backend"
+  subnets         = local.backend_subnet_ids
+  security_groups = [aws_security_group.backend_security_group.id]
+}
+
+resource "aws_apprunner_service" "backend" {
+  service_name = "${var.name}-backend"
+
+  observability_configuration {
+    observability_configuration_arn = aws_apprunner_observability_configuration.backend.arn
+    observability_enabled           = true
+  }
+
+  source_configuration {
+    image_repository {
+      image_configuration {
+        port = var.application.port
+      }
+      image_identifier      = "${var.application.image}:${var.application.tag}"
+      image_repository_type = var.application.repo
+    }
+
+    auto_deployments_enabled = false
+  }
+
+  instance_configuration {
+    cpu                = var.application.cpu
+    memory             = var.application.memory
+    instance_role_arn  = ""
+  }
+
+  network_configuration {
+    ingress_configuration {
+      is_publicly_accessible = var.application.is_public
+    }
+
+    egress_configuration {
+      egress_type       = "VPC"
+      vpc_connector_arn = aws_apprunner_vpc_connector.backend_connector.arn
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,1 +1,5 @@
 data "aws_region" "current" {}
+
+data "http" "personal_public_ip_address" {
+  url = "https://ifconfig.co/ip"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -25,6 +25,12 @@ locals {
     if subnet.tags.type == "apps-private"
   ]
 
+  backend_subnet_ids = [
+    for key, subnet in aws_subnet.subnets :
+    subnet.id
+    if subnet.tags.type == "apps-public"
+  ]
+
   db_subnets_cidrs = [
     for key, subnet in aws_subnet.subnets :
     subnet.cidr_block

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -85,3 +85,26 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
+
+resource "aws_security_group" "backend_security_group" {
+  name   = "backend-security-group"
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    from_port   = var.application.port
+    to_port     = var.application.port
+    protocol    = "tcp"
+    cidr_blocks = ["${trimspace(data.http.personal_public_ip_address.response_body)}/32"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["${trimspace(data.http.personal_public_ip_address.response_body)}/32"]
+  }
+
+  tags = {
+    Name = "backend-security-group"
+  }
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -46,3 +46,11 @@ database = {
   storage  = 20
   instance = "db.t3.micro"
 }
+
+application = {
+  port      = 8080
+  image     = "public.ecr.aws/aws-containers/hello-app-runner"
+  tag       = "latest"
+  repo      = "ECR_PUBLIC"
+  is_public = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -77,6 +77,19 @@ variable "database" {
   description = "A map of database settings."
 }
 
+variable "application" {
+  type = object({
+    port         = number
+    image        = string
+    tag          = string
+    repo         = string
+    cpu          = optional(string, "0.25 vCPU")
+    memory       = optional(string, "0.5 GB")
+    is_public    = optional(bool, false)
+  })
+  description = "A map of all application settings."
+}
+
 variable "db_admin_user" {
   type        = string
   description = "The database user with admin access."


### PR DESCRIPTION
## Background / Context

We need to get going with the third and most important app in our topology - the backend.
To setup the automation and infrastructure, I've used this AWS template app to deploy:
https://github.com/aws-containers/hello-app-runner

It is easy to check and it is simple enough.

## Aim / Implementation

The instance will be in the public VPC subnet and will be public itself. To secure the traffic, only access from specific IPs and to specific IPs is allowed. Currently - this is the IP of the executor of this automation.

## Examples / Tests
I was able to deploy the app successfully:
![Screenshot 2024-05-08 at 16 11 58](https://github.com/mihailgmihaylov/mission-ops/assets/19683080/79b8f43d-aaf9-436d-bbc1-f2acd46f1483)

Also, I got the flying satellite!
![Screenshot 2024-05-08 at 16 12 30](https://github.com/mihailgmihaylov/mission-ops/assets/19683080/a20ed5ca-e846-4583-84ce-776078a9200a)
