### PR TITLE
Add S3 bucket module and new S3 bucket

### DIFF
--- a/terraform/application.tf
+++ b/terraform/application.tf
@@ -35,7 +35,7 @@ resource "aws_apprunner_service" "backend" {
   instance_configuration {
     cpu                = var.application.cpu
     memory             = var.application.memory
-    instance_role_arn  = ""
+    instance_role_arn  = aws_iam_role.backend_role.arn
   }
 
   network_configuration {

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,5 +1,18 @@
 data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 data "http" "personal_public_ip_address" {
   url = "https://ifconfig.co/ip"
+}
+
+data "aws_iam_policy_document" "instance_assume_role" {
+  statement {
+    sid     = "InstanceAssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["tasks.apprunner.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
 }

--- a/terraform/modules/s3/README.md
+++ b/terraform/modules/s3/README.md
@@ -1,0 +1,100 @@
+# Terraform S3 Module
+
+This module makes it easy to create single or multiple S3 buckets in AWS.
+
+It supports creating:
+
+* S3 bucket
+These features of S3 bucket configurations are supported:
+
+* server-side encryption
+* bucket policies
+
+## Minimal example
+
+```
+module "s3" {
+  source = "./modules/s3"
+  names  = ["test-123"]
+}
+```
+
+## Extended example
+
+```
+module "s3" {
+  source = "./modules/s3"
+  names  = ["test-123", "test-321"]
+
+  block_public_access = {
+    test-123 = {}
+    test-321 = {
+      block_public_acls       = false
+      block_public_policy     = false
+      ignore_public_acls      = true
+      restrict_public_buckets = false
+    }
+  }
+
+  force_destroy = {
+    test-123 = true
+  }
+
+  server_side_encryption_configuration = {
+    test-123 = {
+      sse_alogithm = "AES256"
+    }
+
+    test-321 = {
+      sse_alogithm = "AES256"
+    }
+  }
+
+  tags = {
+    test-123 = {
+      "key1" = "value1"
+      "key2" = "value2"
+    }
+    test-321 = {
+      "key3" = "value3"
+      "key4" = "value4"
+    }
+  }
+
+  bucket_policies = {
+    test-123 = [
+      {
+        sid         = "ReadOnly"
+        effect      = "Allow"
+        principals = {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::111111111111:role/some-role-name",
+            "arn:aws:iam::222222222222:role/some-role-name",
+          ]
+        }
+        actions = ["s3:GetObject", "s3:GetObjectVersion"]
+      },
+      {
+        sid         = "ReadWrite"
+        effect      = "Allow"
+        principals = {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::111111111111:role/some-role-name",
+            "arn:aws:iam::222222222222:user/some-user"
+          ]
+        }
+        actions     = [
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+      }
+    ]
+  }
+}
+```

--- a/terraform/modules/s3/data.tf
+++ b/terraform/modules/s3/data.tf
@@ -1,0 +1,16 @@
+data "aws_iam_policy_document" "policy" {
+  for_each = var.bucket_policies
+  dynamic "statement" {
+    for_each = each.value
+    content {
+      sid    = statement.value.sid
+      effect = statement.value.effect
+      principals {
+        type        = statement.value.principals.type
+        identifiers = statement.value.principals.identifiers
+      }
+      actions   = statement.value.actions
+      resources = length(statement.value.resources) > 0 ? statement.value.resources : local.bucket_resources[each.key]
+    }
+  }
+}

--- a/terraform/modules/s3/locals.tf
+++ b/terraform/modules/s3/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  buckets = {
+    for name in var.names :
+    (name) => var.prefix == "" ? name : format("%s-%s", var.prefix, name)
+  }
+
+  bucket_resources = {
+    for name in var.names :
+    (name) => [
+      aws_s3_bucket.buckets[name].arn,
+      "${aws_s3_bucket.buckets[name].arn}/*"
+    ]
+  }
+}

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,13 @@
+output "names" {
+  description = "Map with bucket names."
+  value = { for name, bucket in aws_s3_bucket.buckets :
+    name => bucket.id
+  }
+}
+
+output "arns" {
+  description = "Map with bucket ARNs."
+  value = { for arn, bucket in aws_s3_bucket.buckets :
+    arn => bucket.arn
+  }
+}

--- a/terraform/modules/s3/s3.tf
+++ b/terraform/modules/s3/s3.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "buckets" {
+  for_each      = local.buckets
+  bucket        = each.value
+  force_destroy = lookup(var.force_destroy, each.key, false)
+
+  lifecycle {
+    ignore_changes = [grant]
+  }
+
+  tags = merge(
+    {
+      Name = each.value
+    },
+    lookup(var.tags, each.key, {})
+  )
+}
+
+resource "aws_s3_bucket_policy" "buckets" {
+  for_each = var.bucket_policies
+  bucket   = aws_s3_bucket.buckets[each.key].id
+  policy   = data.aws_iam_policy_document.policy[each.key].json
+}
+
+resource "aws_s3_bucket_public_access_block" "buckets" {
+  for_each = local.buckets
+  bucket   = aws_s3_bucket.buckets[each.key].id
+
+  block_public_acls       = can(var.block_public_access[each.value].block_public_acls) ? var.block_public_access[each.value].block_public_acls : true
+  block_public_policy     = can(var.block_public_access[each.value].block_public_policy) ? var.block_public_access[each.value].block_public_policy : true
+  ignore_public_acls      = can(var.block_public_access[each.value].ignore_public_acls) ? var.block_public_access[each.value].ignore_public_acls : true
+  restrict_public_buckets = can(var.block_public_access[each.value].restrict_public_buckets) ? var.block_public_access[each.value].restrict_public_buckets : true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "buckets" {
+  for_each = var.server_side_encryption_configuration
+  bucket   = aws_s3_bucket.buckets[each.key].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = lookup(each.value, "sse_algorithm", "AES256")
+      kms_master_key_id = lookup(each.value, "kms_master_key_id", null)
+    }
+    bucket_key_enabled = lookup(each.value, "bucket_key_enabled", true)
+  }
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,0 +1,62 @@
+variable "names" {
+  type        = list(string)
+  description = "Bucket name suffixes."
+  validation {
+    condition = alltrue([
+      for bucket in var.names :
+      can(regex("^[a-z0-9][a-z0-9_\\-\\.]{1,61}[a-z0-9]$", bucket))
+      &&
+      (length(distinct(var.names)) == length(var.names))
+    ])
+    error_message = "* Use only lowercase letters, numbers, hyphens (-), and underscores (_). Dots (.) may be used to form a valid domain name. Must start and end with lowercase letter or number. Must be betwen 3 and 63 characters.\n* Should not contain duplicate elements in the list."
+  }
+}
+
+variable "prefix" {
+  description = "Prefix used to generate the bucket name."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.prefix == "" || can(regex("^[a-z0-9][a-z0-9\\-]{1,38}[a-z0-9]$", var.prefix))
+    error_message = "Use only lowercase letters, numbers and hyphens (-). Dots (.) Must start and end with lowercase letter or number. Must be betwen 3 and 40 characters."
+  }
+}
+
+variable "bucket_policies" {
+  type = map(list(object({
+    sid       = optional(string, "")
+    effect    = optional(string, "Allow")
+    actions   = list(string)
+    resources = optional(list(string), [])
+
+    principals = object({
+      type        = optional(string, "AWS")
+      identifiers = list(string)
+    })
+  })))
+  description = "Map of bucket names => policy statement."
+  default     = {}
+}
+
+variable "server_side_encryption_configuration" {
+  type    = map(map(string))
+  default = {}
+}
+
+variable "block_public_access" {
+  type        = map(map(string))
+  description = "Map of bucket names => block_public_access settings."
+  default     = {}
+}
+
+variable "force_destroy" {
+  description = "Optional map of lowercase unprefixed name => boolean, defaults to false."
+  type        = map(bool)
+  default     = {}
+}
+
+variable "tags" {
+  type        = map(map(string))
+  description = "Map of bucket names => map of tags to assign to the bucket."
+  default     = {}
+}

--- a/terraform/modules/s3/versions.tf
+++ b/terraform/modules/s3/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.48"
+    }
+  }
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,61 @@
+module "s3" {
+  source = "./modules/s3"
+  names  = ["${var.name}-bucket"]
+
+  block_public_access = {
+    "${var.name}-bucket" = {
+      block_public_acls       = false
+      block_public_policy     = false
+      ignore_public_acls      = true
+      restrict_public_buckets = false
+    }
+  }
+
+  server_side_encryption_configuration = {
+    "${var.name}-bucket" = {
+      sse_alogithm = "AES256"
+    }
+  }
+
+  bucket_policies = {
+    "${var.name}-bucket" = [
+      {
+        sid         = "ReadOnly"
+        effect      = "Allow"
+        principals = {
+          type = "AWS"
+          identifiers = [
+            aws_iam_role.backend_role.arn
+          ]
+        }
+        actions = [
+          "s3:GetObject",
+          "s3:GetObjectVersion"
+        ]
+      },
+      {
+        sid         = "ReadWrite"
+        effect      = "Allow"
+        principals = {
+          type = "AWS"
+          identifiers = [
+            aws_iam_role.backend_role.arn
+          ]
+        }
+
+        actions = [
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+      }
+    ]
+  }
+
+  tags = {
+    "${var.name}-bucket" = local.tags
+  }
+}

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -108,3 +108,12 @@ resource "aws_security_group" "backend_security_group" {
     Name = "backend-security-group"
   }
 }
+
+resource "aws_iam_role" "backend_role" {
+  name = "backend-role"
+
+  assume_role_policy    = data.aws_iam_policy_document.instance_assume_role.json
+  force_detach_policies = true
+
+  tags = local.tags
+}


### PR DESCRIPTION
## Background / Context

Finally, the S3 bucket is needed to store intermediate data and serve the backend.
To do that, we need to create it, make sure it is encrypted and secure and allow the backend app to access it.

## Aim / Implementation

First, I am creating an S3 module - to abstract the bucket creation and permissions. It is a good practice in the cases where we expect more than one bucket.
For further information how the module works, check out the README.md file in [Add S3 terraform module](https://github.com/mihailgmihaylov/mission-ops/commit/774e18fe50648b5000ac96d8a254d16dfa4a8d8e).

Then we create the new bucket:
![Screenshot 2024-05-09 at 0 03 26](https://github.com/mihailgmihaylov/mission-ops/assets/19683080/d9b07a77-fd36-44f6-9092-75e009fb666c)

Finally, we add an AppRunner role to our runner and assign permissions to the bucket.

## Examples / Tests
<details>
  <summary>Terraform plan</summary>

```
# aws_apprunner_service.backend will be updated in-place
~ resource "aws_apprunner_service" "backend" {
      id                             = "arn:aws:apprunner:eu-central-1:805949414582:service/mission-ops-backend/dd61f53fbb704975bbaf8300e6c25473"
      tags                           = {
          "env"     = "test"
          "project" = "mission-ops"
      }
      # (7 unchanged attributes hidden)

    ~ instance_configuration {
        + instance_role_arn = (known after apply)
          # (2 unchanged attributes hidden)
      }

      # (4 unchanged blocks hidden)
  }

# aws_iam_role.backend_role will be created
+ resource "aws_iam_role" "backend_role" {
    + arn                   = (known after apply)
    + assume_role_policy    = jsonencode(
          {
            + Statement = [
                + {
                    + Action    = "sts:AssumeRole"
                    + Effect    = "Allow"
                    + Principal = {
                        + Service = "build.apprunner.amazonaws.com"
                      }
                  },
              ]
            + Version   = "2012-10-17"
          }
      )
    + create_date           = (known after apply)
    + force_detach_policies = false
    + id                    = (known after apply)
    + managed_policy_arns   = (known after apply)
    + max_session_duration  = 3600
    + name                  = "backend-role"
    + name_prefix           = (known after apply)
    + path                  = "/"
    + tags                  = {
        + "env"     = "test"
        + "project" = "mission-ops"
      }
    + tags_all              = {
        + "env"     = "test"
        + "project" = "mission-ops"
      }
    + unique_id             = (known after apply)
  }

# module.s3.data.aws_iam_policy_document.policy["mission-ops-bucket"] will be read during apply
# (config refers to values not yet known)
<= data "aws_iam_policy_document" "policy" {
    + id   = (known after apply)
    + json = (known after apply)

    + statement {
        + actions   = [
            + "s3:GetObject",
            + "s3:GetObjectVersion",
          ]
        + effect    = "Allow"
        + resources = [
            + (known after apply),
            + (known after apply),
          ]
        + sid       = "ReadOnly"

        + principals {
            + identifiers = [
                + (known after apply),
              ]
            + type        = "AWS"
          }
      }
    + statement {
        + actions   = [
            + "s3:DeleteObject",
            + "s3:GetObject",
            + "s3:GetObjectAcl",
            + "s3:ListBucket",
            + "s3:PutObject",
            + "s3:PutObjectAcl",
          ]
        + effect    = "Allow"
        + resources = [
            + (known after apply),
            + (known after apply),
          ]
        + sid       = "ReadWrite"

        + principals {
            + identifiers = [
                + (known after apply),
              ]
            + type        = "AWS"
          }
      }
  }

# module.s3.aws_s3_bucket.buckets["mission-ops-bucket"] will be created
+ resource "aws_s3_bucket" "buckets" {
    + acceleration_status         = (known after apply)
    + acl                         = (known after apply)
    + arn                         = (known after apply)
    + bucket                      = "mission-ops-bucket"
    + bucket_domain_name          = (known after apply)
    + bucket_prefix               = (known after apply)
    + bucket_regional_domain_name = (known after apply)
    + force_destroy               = false
    + hosted_zone_id              = (known after apply)
    + id                          = (known after apply)
    + object_lock_enabled         = (known after apply)
    + policy                      = (known after apply)
    + region                      = (known after apply)
    + request_payer               = (known after apply)
    + tags                        = {
        + "Name"    = "mission-ops-bucket"
        + "env"     = "test"
        + "project" = "mission-ops"
      }
    + tags_all                    = {
        + "Name"    = "mission-ops-bucket"
        + "env"     = "test"
        + "project" = "mission-ops"
      }
    + website_domain              = (known after apply)
    + website_endpoint            = (known after apply)
  }

# module.s3.aws_s3_bucket_policy.buckets["mission-ops-bucket"] will be created
+ resource "aws_s3_bucket_policy" "buckets" {
    + bucket = (known after apply)
    + id     = (known after apply)
    + policy = (known after apply)
  }

# module.s3.aws_s3_bucket_public_access_block.buckets["mission-ops-bucket"] will be created
+ resource "aws_s3_bucket_public_access_block" "buckets" {
    + block_public_acls       = false
    + block_public_policy     = false
    + bucket                  = (known after apply)
    + id                      = (known after apply)
    + ignore_public_acls      = true
    + restrict_public_buckets = false
  }

# module.s3.aws_s3_bucket_server_side_encryption_configuration.buckets["mission-ops-bucket"] will be created
+ resource "aws_s3_bucket_server_side_encryption_configuration" "buckets" {
    + bucket = (known after apply)
    + id     = (known after apply)

    + rule {
        + bucket_key_enabled = true

        + apply_server_side_encryption_by_default {
            + sse_algorithm = "AES256"
          }
      }
  }

Plan: 5 to add, 1 to change, 0 to destroy.
```

</details>