### PR TITLE
Make s3 buckets templatable

### DIFF
--- a/terraform/modules/s3/README.md
+++ b/terraform/modules/s3/README.md
@@ -42,11 +42,11 @@ module "s3" {
 
   server_side_encryption_configuration = {
     test-123 = {
-      sse_alogithm = "AES256"
+      sse_algorithm = "AES256"
     }
 
     test-321 = {
-      sse_alogithm = "AES256"
+      sse_algorithm = "AES256"
     }
   }
 

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,24 +1,27 @@
 module "s3" {
   source = "./modules/s3"
-  names  = ["${var.name}-bucket"]
+  names  = var.buckets.names
 
   block_public_access = {
-    "${var.name}-bucket" = {
-      block_public_acls       = false
-      block_public_policy     = false
-      ignore_public_acls      = true
-      restrict_public_buckets = false
+    for name in var.buckets.names :
+    name => {
+      block_public_acls       = var.buckets.block_public_acls
+      block_public_policy     = var.buckets.block_public_policy
+      ignore_public_acls      = var.buckets.ignore_public_acls
+      restrict_public_buckets = var.buckets.restrict_public_buckets
     }
   }
 
   server_side_encryption_configuration = {
-    "${var.name}-bucket" = {
-      sse_alogithm = "AES256"
+    for name in var.buckets.names :
+    name => {
+      sse_algorithm = var.buckets.sse_algorithm
     }
   }
 
   bucket_policies = {
-    "${var.name}-bucket" = [
+    for name in var.buckets.names :
+    name => [
       {
         sid         = "ReadOnly"
         effect      = "Allow"
@@ -56,6 +59,7 @@ module "s3" {
   }
 
   tags = {
-    "${var.name}-bucket" = local.tags
+    for name in var.buckets.names :
+    name => local.tags
   }
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -54,3 +54,7 @@ application = {
   repo      = "ECR_PUBLIC"
   is_public = true
 }
+
+buckets = {
+  names = ["mission-ops-test"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -90,6 +90,18 @@ variable "application" {
   description = "A map of all application settings."
 }
 
+variable "buckets" {
+  type = object({
+    names                   = list(string)
+    block_public_acls       = optional(bool, false)
+    block_public_policy     = optional(bool, false)
+    ignore_public_acls      = optional(bool, true)
+    restrict_public_buckets = optional(bool, false)
+    sse_algorithm           = optional(string, "AES256")
+  })
+  description = "A map of all S3 bucket settings."
+}
+
 variable "db_admin_user" {
   type        = string
   description = "The database user with admin access."


### PR DESCRIPTION
## Background / Context
The S3 module can support more than one bucket creation. Additionally it is a very well defined templating engine.
However, up to this point, I've defined the configurations inline in the module definition. This PR changes that.

## Aim / Implementation

Create a new variable - `buckets`, that will store all buckets and their values.
Thus we can create more than one bucket and abstract the values in a well-defined variable:
![Screenshot 2024-05-09 at 0 03 26](https://github.com/mihailgmihaylov/mission-ops/assets/19683080/a028ce8e-d5a2-4deb-b4eb-6a63da6a1156)

## Examples / Tests

<details>
  <summary>Terraform plan</summary>

```
# module.s3.aws_s3_bucket.buckets["mission-ops-test"] will be created
  + resource "aws_s3_bucket" "buckets" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "mission-ops-test"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "Name"    = "mission-ops-test"
          + "env"     = "test"
          + "project" = "mission-ops"
        }
      + tags_all                    = {
          + "Name"    = "mission-ops-test"
          + "env"     = "test"
          + "project" = "mission-ops"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # module.s3.aws_s3_bucket_policy.buckets["mission-ops-test"] will be created
  + resource "aws_s3_bucket_policy" "buckets" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.s3.aws_s3_bucket_public_access_block.buckets["mission-ops-test"] will be created
  + resource "aws_s3_bucket_public_access_block" "buckets" {
      + block_public_acls       = false
      + block_public_policy     = false
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = false
    }

  # module.s3.aws_s3_bucket_server_side_encryption_configuration.buckets["mission-ops-test"] will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "buckets" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + bucket_key_enabled = true

          + apply_server_side_encryption_by_default {
              + sse_algorithm = "AES256"
            }
        }
    }
```

</details>